### PR TITLE
Reactive response to accept and continue button

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Place `{{> cookieConsent}}`  or `{{> cookieConsentImply}}` in your main template
 ```handlebars
 <body>
     {{> cookieConsent}}
-    or 
+    or
     {{> cookieConsentImply}}
 </body>
 ```
@@ -29,25 +29,26 @@ and then place under client/lib/cookie_consent.js file the initialisation code
 var options = {
   cookieTitle: "We use Cookies",
   cookieMessage: "We are using cookies to give you the best"
-     + " experience on our site. Cookies are files stored in your" 
+     + " experience on our site. Cookies are files stored in your"
      + " browser and are used by most websites to help personalise your web experience.",
   showLink: true,
   linkText: "Read more",
   linkRouteName: "/cookiePolicy",
   acceptButtonText: "Accept and Continue",
   html: false,
-  expirationInDays: 7
+  expirationInDays: 7,
+  forceShow: false
 };
 
 CookieConsent.init(options);
 
-// or 
+// or
 
 var optionsImply = {
   cookieMessage: "We are using cookies to give you the best"
-     + " experience on our site. Cookies are files stored in your" 
+     + " experience on our site. Cookies are files stored in your"
      + " browser and are used by most websites to help personalise your web experience.",
-  cookieMessageImply: "By continuing to use our website without changing the settings," 
+  cookieMessageImply: "By continuing to use our website without changing the settings,"
     + " you are agreeing to our use of cookies.",
   showLink: true,
   position: 'top',
@@ -55,7 +56,8 @@ var optionsImply = {
   linkRouteName: "/cookiePolicy",
   html: false,
   className: null,
-  expirationInDays: 7
+  expirationInDays: 7,
+  forceShow: false
 };
 
 CookieConsent.init(optionsImply);

--- a/client/cookie_consent.js
+++ b/client/cookie_consent.js
@@ -1,3 +1,5 @@
+var cookies = new Cookies();
+
 const helpers = {
   acceptButtonText: function(){
     return CookieConsent.getConfig('acceptButtonText');
@@ -30,7 +32,10 @@ const helpers = {
     return CookieConsent.getConfig('expirationInDays') || 7;
   },
   showMessage: function(){
-    let cookie = Cookie.get('cookie-consent');
+    if (CookieConsent.getConfig('forceShow')) {
+      return true;
+    }
+    let cookie = Template.instance().cookieStatus.get();
     if (cookie){
       return false;
     }else{
@@ -38,6 +43,11 @@ const helpers = {
     }
   },
 };
+
+Template.cookieConsent.onCreated(function() {
+  this.cookieStatus = new ReactiveVar();
+  this.cookieStatus.set(cookies.get('cookie-consent'));
+});
 
 Template.cookieConsent.helpers(helpers);
 
@@ -49,6 +59,7 @@ Template.cookieConsent.events({
     let expireInDays = CookieConsent.getConfig('expirationInDays') || 7;
     let dt = new Date();
     dt.setTime(dt.getTime() + (expireInDays*24*60*60*1000));
-    Cookie.set('cookie-consent', "Accepted", {expires: dt});
+    cookies.set('cookie-consent', "Accepted", {expires: dt});
+    Template.instance().cookieStatus.set(cookies.get('cookie-consent'));
   }
 });

--- a/cookie_consent.js
+++ b/cookie_consent.js
@@ -26,7 +26,8 @@ var _defaults = {
   linkRouteName: "/cookiePolicy",
   acceptButtonText: "Accept and Continue",
   html: false,
-  expirationInDays: 7
+  expirationInDays: 7,
+  forceShow: false
 };
 
 CookieConsent.getConfig = (paramName) => {

--- a/package.js
+++ b/package.js
@@ -8,15 +8,15 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.versionsFrom("METEOR@1.2.1");
-	api.use(['templating', 'check', 'underscore', 'ecmascript'], 'client');
- 
-  api.use('chuangbo:cookie@1.1.0', 'client');
-  
+	api.use(['templating', 'check', 'underscore', 'ecmascript', 'reactive-var'], 'client');
+
+  api.use('ostrio:cookies');
+
   api.addFiles('cookie_consent.js', 'client');
-  
+
   api.addFiles('client/cookie_consent.css', 'client');
   api.addFiles('client/cookie_consent.html', 'client');
   api.addFiles('client/cookie_consent.js', 'client');
-  
+
   api.export('CookieConsent', 'client');
 });

--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  name: 'selaias:cookie-consent',
+  name: 'carl:cookie-consent',
   version: '0.3.0',
   summary: 'Easily and fully customizable EU Cookie Consent alert.',
   git: 'http://github.com/selaias/meteor-cookie-consent.git',


### PR DESCRIPTION
In the current version, when clicking accept and continue the box remains until the template is refreshed. 

In order to get around this `showMessage` now depends on a reactive variable which holds the current cookie value. This is updated when the cookie gets set so the message disappears instantly. 

Have also updated the package used for providing cookie support, as the one in the package is no longer maintained. 