### PR TITLE
updating ostrio:cookies package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Create easily a fully customizable bootstrap EU Law (imply) Cookie consent banne
 $ meteor add selaias:cookie-consent
 ```
 
-This packages makes also use of cookies via the `chuangbo:cookie` package.
+This packages makes also use of cookies via the `ostrio:cookies` package.
 
 ## Usage
 

--- a/client/cookie_consent.js
+++ b/client/cookie_consent.js
@@ -1,3 +1,4 @@
+import { Cookies } from 'meteor/ostrio:cookies';
 var cookies = new Cookies();
 
 const helpers = {

--- a/package.js
+++ b/package.js
@@ -10,7 +10,7 @@ Package.onUse(function(api) {
   api.versionsFrom("METEOR@1.4");
 	api.use(['templating', 'check', 'underscore', 'ecmascript', 'reactive-var'], 'client');
 
-  api.use('ostrio:cookies@2.1.2');
+  api.use('ostrio:cookies@2.2.0');
 
   api.addFiles('cookie_consent.js', 'client');
 


### PR DESCRIPTION
Apparently the latest update to the ostrio:cookies package requires the package to be explicitly imported. 

Updates to reflect this and updating README (forgot to do this on my last RR) 😸 